### PR TITLE
ya no permite ingresar otra cosa que no sean letras

### DIFF
--- a/src/components/Registrarse.jsx
+++ b/src/components/Registrarse.jsx
@@ -83,6 +83,10 @@ const Registrarse = () => {
                         message:
                           "El Nombre debe tener un máximo de 3 caracteres",
                       },
+                      pattern: {
+                        value:  /^[a-zA-Z\u00C0-\u024F\s]+$/,
+                        message: "Solo se permite ingresar letras"
+                      }
                     })}
                   />
                 </Form.Group>


### PR DESCRIPTION
Limite el ingreso de datos a solo letras en el input nombre de registro.